### PR TITLE
Handle transient Reddit feed failures

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -1,12 +1,14 @@
 <?php
+    header( 'Content-Type: application/json' );
+
     if ( isset( $_GET[ 'r' ] ) ) {
-        $subreddit = preg_replace( '#[^a-zA-Z_+]+#', '', $_GET[ 'r' ] );
+        $subreddit = preg_replace( '#[^a-zA-Z0-9_+-]+#', '', $_GET[ 'r' ] );
     }
     else {
         $subreddit = 'funny';
     }
     if ( isset( $_GET[ 'limit' ] ) ) {
-        $limit = ( int )$_GET[ 'limit' ];
+        $limit = max( 1, min( 100, ( int )$_GET[ 'limit' ] ) );
     }
     else {
         $limit = 25;
@@ -17,6 +19,23 @@
     else {
         $after = '';
     }
-    $url = 'http://www.reddit.com/r/' . $subreddit . '.json?limit=' . $limit . '&after=' . $after;
-    echo file_get_contents( $url );
+    $url = 'https://www.reddit.com/r/' . $subreddit . '.json?limit=' . $limit . '&after=' . $after;
+    $context = stream_context_create( array(
+        'http' => array(
+            'header' => "User-Agent: minireddit/1.0\r\n",
+            'timeout' => 10,
+        ),
+    ) );
+    $response = @file_get_contents( $url, false, $context );
+
+    if ( $response === false ) {
+        http_response_code( 502 );
+        echo json_encode( array(
+            'error' => true,
+            'message' => 'Could not load subreddit feed from reddit.',
+        ) );
+        exit;
+    }
+
+    echo $response;
 ?>

--- a/js/behavior.js
+++ b/js/behavior.js
@@ -15,6 +15,11 @@ function endOfChannel() {
     console.log('End of subreddit.');
     Render.end();
 }
+function networkError() {
+    console.log('Subreddit feed could not be loaded.');
+    Render.networkError();
+}
+channel.onerror = networkError;
 
 /*
 $('#img').hide();

--- a/js/reddit.js
+++ b/js/reddit.js
@@ -5,10 +5,16 @@ var Reddit = {
         $.get('post.php', {
             name: name
         }, function(postList) {
+            if (postList == null || postList.error) {
+                Render.networkError();
+                return;
+            }
             var post = postList.data.children[0].data;
 
             callback(new Reddit.Post(post));
-        }, 'json');
+        }, 'json').fail(function() {
+            Render.networkError();
+        });
     },
     Post: function(data) {
         this.name = data.name;
@@ -22,11 +28,14 @@ var Reddit = {
         }
         this.subreddits = subreddits;
         this.items = [];
+        this.after = '';
         this.currentID = 0;
         this.limit = 25;
+        this.retryLimit = 2;
 
         this.onnewitemavailable = function() {};
         this.onerror = function() {};
+        this.onend = function() {};
     },
 };
 
@@ -44,29 +53,25 @@ Reddit.Channel.prototype = {
         // we don't yet have the current item; download it
         this.downloadNextPage(function() {
             callback(self.items[self.currentID]);
-        }, this.onerror);
+        }, this.onend, this.onerror);
     },
-    downloadNextPage: function(ondone, onerror) {
-        var after;
+    downloadNextPage: function(ondone, onend, onerror, retries) {
         var self = this;
+        retries = retries || 0;
+        var requestedAfter = this.after;
 
-        if (this.items.length == 0) {
-            after = '';
-        }
-        else {
-            after = this.items[this.items.length - 1].name;
-        }
-        $.get('feed.php', {
+        var request = $.get('feed.php', {
             r: this.subreddits.join('+'),
-            after: after,
+            after: this.after,
             limit: this.limit
         }, function(feed) {
             var prevlength = self.items.length;
 
-            if (feed == null) {
+            if (feed == null || feed.error || !feed.data || !feed.data.children) {
                 Render.invalid();
                 return;
             }
+            self.after = feed.data.after || '';
             feed.data.children = feed.data.children.map(function(item) {
                 return new Reddit.Post(item.data);
             }).filter(function(item) {
@@ -91,18 +96,31 @@ Reddit.Channel.prototype = {
             }
 
             if (prevlength == newlength) {
-                // we ran out of pages
+                if (self.after != '' && self.after != requestedAfter) {
+                    self.downloadNextPage(ondone, onend, onerror, retries);
+                    return;
+                }
                 console.log('End of subreddit.');
-                self.onerror();
+                onend();
             }
             else {
                 ondone();
             }
         }, 'json');
+
+        request.fail(function() {
+            if (retries < self.retryLimit) {
+                console.log('Retrying subreddit feed after transient failure.');
+                self.downloadNextPage(ondone, onend, onerror, retries + 1);
+                return;
+            }
+            console.log('Could not load subreddit feed.');
+            onerror();
+        });
     },
     goNext: function(onerror) {
         if (typeof onerror == 'function') {
-            this.onerror = onerror;
+            this.onend = onerror;
         }
 
         ++this.currentID;

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -57,6 +57,11 @@ var Render = {
         $('h2.title').html('<em>This subreddit does not exist.</em>');
         Render.stopLoading();
     },
+    networkError: function() {
+        $('#img').hide();
+        $('h2.title').html('<em>Could not load more content. Please try again.</em>');
+        Render.stopLoading();
+    },
     moveOut: function($img) {
         $img.css({
             webkitTransform: 'perspective(' + Render.ANIMATION_PERSPECTIVE + 'px) rotateY(-60deg)',

--- a/post.php
+++ b/post.php
@@ -3,6 +3,14 @@
 
     if ( isset( $_GET[ 'name' ] ) ) {
         $name = preg_replace( '#[^a-zA-Z0-9_]+#', '', $_GET[ 'name' ] );
+        if ( $name === '' ) {
+            http_response_code( 400 );
+            echo json_encode( array(
+                'error' => true,
+                'message' => 'Invalid post id.',
+            ) );
+            exit;
+        }
         $context = stream_context_create( array(
             'http' => array(
                 'header' => "User-Agent: minireddit/1.0\r\n",

--- a/post.php
+++ b/post.php
@@ -1,5 +1,25 @@
 <?php
+    header( 'Content-Type: application/json' );
+
     if ( isset( $_GET[ 'name' ] ) ) {
-        echo file_get_contents( 'http://www.reddit.com/by_id/' . $_GET[ 'name' ] . '.json' );
+        $name = preg_replace( '#[^a-zA-Z0-9_]+#', '', $_GET[ 'name' ] );
+        $context = stream_context_create( array(
+            'http' => array(
+                'header' => "User-Agent: minireddit/1.0\r\n",
+                'timeout' => 10,
+            ),
+        ) );
+        $response = @file_get_contents( 'https://www.reddit.com/by_id/' . $name . '.json', false, $context );
+
+        if ( $response === false ) {
+            http_response_code( 502 );
+            echo json_encode( array(
+                'error' => true,
+                'message' => 'Could not load post from reddit.',
+            ) );
+            exit;
+        }
+
+        echo $response;
     }
 ?>


### PR DESCRIPTION
Fixes #21

## Summary
- return explicit JSON errors from the Reddit proxy endpoints when upstream requests fail
- use HTTPS plus a User-Agent for Reddit requests
- retry transient feed failures before surfacing a network error
- track Reddit's `after` cursor separately so duplicate/filtered pages do not falsely mean the subreddit is exhausted
- keep true end-of-feed rendering separate from network failure rendering

## Verification
- `node --check js/reddit.js`
- `node --check js/behavior.js`
- `node --check js/renderer.js`
- `D:\tools\php-8.4-latest\php.exe -l feed.php`
- `D:\tools\php-8.4-latest\php.exe -l post.php`